### PR TITLE
Rewrite without using OpenCensus metrics

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -53,10 +53,6 @@ type MetricsConfig struct {
 	// By default metrics are not namespaced
 	Namespace string `mapstructure:"namespace"`
 
-	// Percentiles states whether to report percentiles for summary metrics,
-	// including the minimum and maximum
-	Percentiles bool `mapstructure:"report_percentiles"`
-
 	// Buckets states whether to report buckets from distribution metrics
 	Buckets bool `mapstructure:"report_buckets"`
 

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -63,8 +63,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 
 		Metrics: MetricsConfig{
-			Namespace:   "opentelemetry.",
-			Percentiles: false,
+			Namespace: "opentelemetry.",
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "https://api.datadoghq.eu",
 			},

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -53,7 +53,6 @@ func createDefaultConfig() configmodels.Exporter {
 		},
 
 		Metrics: MetricsConfig{
-			Percentiles: true,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "", // set during config sanitization
 			},

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -42,9 +42,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 		},
 		API: APIConfig{Site: "datadoghq.com"},
-		Metrics: MetricsConfig{
-			Percentiles: true,
-		},
 	}, cfg, "failed to create default config")
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
@@ -73,8 +72,7 @@ func (exp *metricsExporter) processMetrics(series *Series) {
 }
 
 func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
-	data := internaldata.MetricsToOC(md)
-	series, droppedTimeSeries := MapMetrics(exp.logger, exp.cfg.Metrics, data)
+	series, droppedTimeSeries := MapMetrics(exp.logger, exp.cfg.Metrics, md)
 	exp.processMetrics(&series)
 
 	err := exp.client.PostMetrics(series.metrics)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -102,7 +102,6 @@ func TestProcessMetrics(t *testing.T) {
 
 	var series Series
 	series.Add(NewGauge(
-		"original_host",
 		"metric_name",
 		0,
 		0,

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -16,10 +16,8 @@ package datadogexporter
 
 import (
 	"fmt"
-	"math"
 
-	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
@@ -28,27 +26,17 @@ const (
 	Gauge string = "gauge"
 )
 
-func NewGauge(hostname, name string, ts int32, value float64, tags []string) datadog.Metric {
+func NewGauge(name string, ts int32, value float64, tags []string) datadog.Metric {
 	timestamp := float64(ts)
 
 	gauge := datadog.Metric{
 		Points: []datadog.DataPoint{[2]*float64{&timestamp, &value}},
 		Tags:   tags,
 	}
-	gauge.SetHost(hostname)
 	gauge.SetMetric(name)
 	gauge.SetType(Gauge)
 	return gauge
 }
-
-type OpenCensusKind int
-
-const (
-	Int64 OpenCensusKind = iota
-	Double
-	Distribution
-	Summary
-)
 
 // Series is a set of metrics
 type Series struct {
@@ -59,156 +47,168 @@ func (m *Series) Add(metric datadog.Metric) {
 	m.metrics = append(m.metrics, metric)
 }
 
-func MapMetrics(logger *zap.Logger, metricsCfg MetricsConfig, data []consumerdata.MetricsData) (series Series, droppedTimeSeries int) {
+func getTags(labels pdata.StringMap) []string {
+	tags := make([]string, 0, labels.Len())
+	labels.ForEach(func(key string, v pdata.StringValue) {
+		value := v.Value()
+		if value == "" {
+			// Tags can't end with ":" so we replace empty values with "n/a"
+			value = "n/a"
+		}
+		tags = append(tags, fmt.Sprintf("%s:%s", key, value))
+	})
+	return tags
+}
 
-	for _, metricsData := range data {
-		// The hostname provided by OpenTelemetry
-		host := metricsData.Node.GetIdentifier().GetHostName()
+func mapIntMetrics(name string, slice pdata.IntDataPointSlice) []datadog.Metric {
+	// Allocate assuming none are nil
+	metrics := make([]datadog.Metric, 0, slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		p := slice.At(i)
+		if p.IsNil() {
+			continue
+		}
+		metrics = append(metrics,
+			NewGauge(name, int32(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
+		)
+	}
+	return metrics
+}
 
-		for _, metric := range metricsData.Metrics {
+func mapDoubleMetrics(name string, slice pdata.DoubleDataPointSlice) []datadog.Metric {
+	// Allocate assuming none are nil
+	metrics := make([]datadog.Metric, 0, slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		p := slice.At(i)
+		if p.IsNil() {
+			continue
+		}
+		metrics = append(metrics,
+			NewGauge(name, int32(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
+		)
+	}
+	return metrics
+}
 
-			// The metric name
-			name := metric.GetMetricDescriptor().GetName()
-			// For logging purposes
-			nameField := zap.String("name", name)
+// mapIntHistogramMetrics maps histogram metrics slices to Datadog metrics
+//
+// A Histogram metric has:
+// - The count of values in the population
+// - The sum of values in the population
+// - A number of buckets, each of them having
+//    - the bounds that define the bucket
+//    - the count of the number of items in that bucket
+//    - a sample value from each bucket
+//
+// We follow a similar approach to OpenCensus:
+// we report sum and count by default; buckets count can also
+// be reported (opt-in), but bounds are ignored.
+func mapIntHistogramMetrics(name string, slice pdata.IntHistogramDataPointSlice, buckets bool) []datadog.Metric {
+	// Allocate assuming none are nil and no buckets
+	metrics := make([]datadog.Metric, 0, 2*slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		p := slice.At(i)
+		if p.IsNil() {
+			continue
+		}
+		ts := int32(p.Timestamp())
+		tags := getTags(p.LabelsMap())
 
-			// Labels are divided in keys and values, keys are shared among timeseries.
-			// We transform them into Datadog tags of the form key:value
-			labelKeys := metric.GetMetricDescriptor().GetLabelKeys()
+		metrics = append(metrics,
+			NewGauge(fmt.Sprintf("%s.count", name), ts, float64(p.Count()), tags),
+			NewGauge(fmt.Sprintf("%s.sum", name), ts, float64(p.Sum()), tags),
+		)
 
-			// Get information about metric
-			// We ignore whether the metric is cumulative or not
-			var kind OpenCensusKind
-			switch metric.GetMetricDescriptor().GetType() {
-			case v1.MetricDescriptor_GAUGE_INT64, v1.MetricDescriptor_CUMULATIVE_INT64:
-				kind = Int64
-			case v1.MetricDescriptor_GAUGE_DOUBLE, v1.MetricDescriptor_CUMULATIVE_DOUBLE:
-				kind = Double
-			case v1.MetricDescriptor_GAUGE_DISTRIBUTION, v1.MetricDescriptor_CUMULATIVE_DISTRIBUTION:
-				kind = Distribution
-			case v1.MetricDescriptor_SUMMARY:
-				kind = Summary
-			default:
-				logger.Info(
-					"Discarding metric: unspecified or unrecognized type",
-					nameField,
-					zap.Any("type", metric.GetMetricDescriptor().GetType()),
+		if buckets {
+			// We have a single metric, 'count_per_bucket', which is tagged with the bucket id. See:
+			// https://github.com/DataDog/opencensus-go-exporter-datadog/blob/c3b47f1c6dcf1c47b59c32e8dbb7df5f78162daa/stats.go#L99-L104
+			fullName := fmt.Sprintf("%s.count_per_bucket", name)
+			for idx, count := range p.BucketCounts() {
+				bucketTags := append(tags, fmt.Sprintf("bucket_idx:%d", idx))
+				metrics = append(metrics,
+					NewGauge(fullName, ts, float64(count), bucketTags),
 				)
-				droppedTimeSeries += len(metric.GetTimeseries())
-				continue
-			}
-
-			for _, timeseries := range metric.GetTimeseries() {
-
-				// Create tags
-				labelValues := timeseries.GetLabelValues()
-				tags := make([]string, len(labelKeys))
-				for i, key := range labelKeys {
-					labelValue := labelValues[i]
-					if labelValue.GetHasValue() {
-						// Tags can't end with ":" so we replace empty values with "n/a"
-						value := labelValue.GetValue()
-						if value == "" {
-							value = "n/a"
-						}
-
-						tags[i] = fmt.Sprintf("%s:%s", key.GetKey(), value)
-					}
-				}
-
-				for _, point := range timeseries.GetPoints() {
-					ts := int32(point.Timestamp.Seconds)
-
-					switch kind {
-					case Int64:
-						series.Add(NewGauge(host, name, ts, float64(point.GetInt64Value()), tags))
-					case Double:
-						series.Add(NewGauge(host, name, ts, point.GetDoubleValue(), tags))
-					case Distribution:
-						// A Distribution metric has:
-						// - The count of values in the population
-						// - The sum of values in the population
-						// - The sum of squared deviations
-						// - A number of buckets, each of them having
-						//    - the bounds that define the bucket
-						//    - the count of the number of items in that bucket
-						//    - a sample value from each bucket
-						//
-						// We follow the implementation on `opencensus-go-exporter-datadog`:
-						// we report the first three values and the buckets count can also
-						// be reported (opt-in), but bounds are ignored.
-
-						dist := point.GetDistributionValue()
-
-						distMetrics := map[string]float64{
-							"count":           float64(dist.GetCount()),
-							"sum":             dist.GetSum(),
-							"squared_dev_sum": dist.GetSumOfSquaredDeviation(),
-						}
-
-						for suffix, value := range distMetrics {
-							fullName := fmt.Sprintf("%s.%s", name, suffix)
-							series.Add(NewGauge(host, fullName, ts, value, tags))
-						}
-
-						if metricsCfg.Buckets {
-							// We have a single metric, 'count_per_bucket', which is tagged with the bucket id. See:
-							// https://github.com/DataDog/opencensus-go-exporter-datadog/blob/c3b47f1c6dcf1c47b59c32e8dbb7df5f78162daa/stats.go#L99-L104
-							fullName := fmt.Sprintf("%s.count_per_bucket", name)
-
-							for idx, bucket := range dist.GetBuckets() {
-								bucketTags := append(tags, fmt.Sprintf("bucket_idx:%d", idx))
-								series.Add(NewGauge(host, fullName, ts, float64(bucket.GetCount()), bucketTags))
-							}
-						}
-					case Summary:
-						// A Summary metric has:
-						// - The total sum so far
-						// - The total count so far
-						// - A snapshot with
-						//   - the sum in the current snapshot
-						//   - the count in the current snapshot
-						//   - a series of percentiles
-						//
-						// By default we report the sum and count as gauges and percentiles.
-						// Percentiles are opt-out
-
-						// Report count if available
-						if count := point.GetSummaryValue().GetCount(); count != nil {
-							fullName := fmt.Sprintf("%s.count", name)
-							series.Add(NewGauge(host, fullName, ts, float64(count.GetValue()), tags))
-						}
-
-						// Report sum if available
-						if sum := point.GetSummaryValue().GetSum(); sum != nil {
-							fullName := fmt.Sprintf("%s.sum", name)
-							series.Add(NewGauge(host, fullName, ts, sum.GetValue(), tags))
-						}
-
-						if metricsCfg.Percentiles {
-							snapshot := point.GetSummaryValue().GetSnapshot()
-							for _, pair := range snapshot.GetPercentileValues() {
-								var fullName string
-								if perc := pair.GetPercentile(); perc == 0 {
-									// p0 is the minimum
-									fullName = fmt.Sprintf("%s.min", name)
-								} else if perc == 100 {
-									// p100 is the maximum
-									fullName = fmt.Sprintf("%s.max", name)
-								} else {
-									// Round to the nearest digit
-									fullName = fmt.Sprintf("%s.p%02d", name, int(math.Round(perc)))
-								}
-
-								series.Add(NewGauge(host, fullName, ts, pair.GetValue(), tags))
-							}
-						}
-
-					}
-				}
 			}
 		}
 	}
+	return metrics
+}
 
+// mapIntHistogramMetrics maps double histogram metrics slices to Datadog metrics
+//
+// see mapIntHistogramMetrics docs for further details.
+func mapDoubleHistogramMetrics(name string, slice pdata.DoubleHistogramDataPointSlice, buckets bool) []datadog.Metric {
+	// Allocate assuming none are nil and no buckets
+	metrics := make([]datadog.Metric, 0, 2*slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		p := slice.At(i)
+		if p.IsNil() {
+			continue
+		}
+		ts := int32(p.Timestamp())
+		tags := getTags(p.LabelsMap())
+
+		metrics = append(metrics,
+			NewGauge(fmt.Sprintf("%s.count", name), ts, float64(p.Count()), tags),
+			NewGauge(fmt.Sprintf("%s.sum", name), ts, float64(p.Sum()), tags),
+		)
+
+		if buckets {
+			// We have a single metric, 'count_per_bucket', which is tagged with the bucket id. See:
+			// https://github.com/DataDog/opencensus-go-exporter-datadog/blob/c3b47f1c6dcf1c47b59c32e8dbb7df5f78162daa/stats.go#L99-L104
+			fullName := fmt.Sprintf("%s.count_per_bucket", name)
+			for idx, count := range p.BucketCounts() {
+				bucketTags := append(tags, fmt.Sprintf("bucket_idx:%d", idx))
+				metrics = append(metrics,
+					NewGauge(fullName, ts, float64(count), bucketTags),
+				)
+			}
+		}
+	}
+	return metrics
+}
+
+func MapMetrics(logger *zap.Logger, cfg MetricsConfig, md pdata.Metrics) (series Series, droppedTimeSeries int) {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		if rm.IsNil() {
+			continue
+		}
+		ilms := rm.InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+			if ilm.IsNil() {
+				continue
+			}
+			metrics := ilm.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				md := metrics.At(k)
+				if md.IsNil() {
+					continue
+				}
+				var datapoints []datadog.Metric
+				switch md.DataType() {
+				case pdata.MetricDataTypeNone:
+					continue
+				case pdata.MetricDataTypeIntGauge:
+					datapoints = mapIntMetrics(md.Name(), md.IntGauge().DataPoints())
+				case pdata.MetricDataTypeDoubleGauge:
+					datapoints = mapDoubleMetrics(md.Name(), md.DoubleGauge().DataPoints())
+				case pdata.MetricDataTypeIntSum:
+					// Ignore aggregation temporality; report raw values
+					datapoints = mapIntMetrics(md.Name(), md.IntSum().DataPoints())
+				case pdata.MetricDataTypeDoubleSum:
+					// Ignore aggregation temporality; report raw values
+					datapoints = mapDoubleMetrics(md.Name(), md.DoubleSum().DataPoints())
+				case pdata.MetricDataTypeIntHistogram:
+					datapoints = mapIntHistogramMetrics(md.Name(), md.IntHistogram().DataPoints(), cfg.Buckets)
+				case pdata.MetricDataTypeDoubleHistogram:
+					datapoints = mapDoubleHistogramMetrics(md.Name(), md.DoubleHistogram().DataPoints(), cfg.Buckets)
+				}
+				series.metrics = append(series.metrics, datapoints...)
+			}
+		}
+	}
 	return
 }

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -26,8 +26,10 @@ const (
 	Gauge string = "gauge"
 )
 
-func NewGauge(name string, ts int32, value float64, tags []string) datadog.Metric {
-	timestamp := float64(ts)
+func NewGauge(name string, ts uint64, value float64, tags []string) datadog.Metric {
+	// Transform UnixNano timestamp into Unix timestamp
+	// 1 second = 1e9 ns
+	timestamp := float64(ts / 1e9)
 
 	gauge := datadog.Metric{
 		Points: []datadog.DataPoint{[2]*float64{&timestamp, &value}},
@@ -69,7 +71,7 @@ func mapIntMetrics(name string, slice pdata.IntDataPointSlice) []datadog.Metric 
 			continue
 		}
 		metrics = append(metrics,
-			NewGauge(name, int32(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
+			NewGauge(name, uint64(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
 		)
 	}
 	return metrics
@@ -84,7 +86,7 @@ func mapDoubleMetrics(name string, slice pdata.DoubleDataPointSlice) []datadog.M
 			continue
 		}
 		metrics = append(metrics,
-			NewGauge(name, int32(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
+			NewGauge(name, uint64(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())),
 		)
 	}
 	return metrics
@@ -111,7 +113,7 @@ func mapIntHistogramMetrics(name string, slice pdata.IntHistogramDataPointSlice,
 		if p.IsNil() {
 			continue
 		}
-		ts := int32(p.Timestamp())
+		ts := uint64(p.Timestamp())
 		tags := getTags(p.LabelsMap())
 
 		metrics = append(metrics,
@@ -145,7 +147,7 @@ func mapDoubleHistogramMetrics(name string, slice pdata.DoubleHistogramDataPoint
 		if p.IsNil() {
 			continue
 		}
-		ts := int32(p.Timestamp())
+		ts := uint64(p.Timestamp())
 		tags := getTags(p.LabelsMap())
 
 		metrics = append(metrics,

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -28,7 +28,7 @@ func TestMetricValue(t *testing.T) {
 	var (
 		name  string   = "name"
 		value float64  = math.Pi
-		ts    int32    = int32(time.Now().Unix())
+		ts    uint64   = uint64(time.Now().UnixNano())
 		tags  []string = []string{"tool:opentelemetry", "version:0.1.0"}
 	)
 
@@ -42,7 +42,7 @@ func TestGetTags(t *testing.T) {
 	labels.InitFromMap(map[string]string{
 		"key1": "val1",
 		"key2": "val2",
- 		"key3": "",			   
+		"key3": "",
 	})
 
 	assert.ElementsMatch(t,
@@ -52,7 +52,7 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestMapIntMetrics(t *testing.T) {
-	ts := time.Now().Unix()
+	ts := time.Now().UnixNano()
 	slice := pdata.NewIntDataPointSlice()
 
 	point := pdata.NewIntDataPoint()
@@ -66,12 +66,12 @@ func TestMapIntMetrics(t *testing.T) {
 
 	assert.ElementsMatch(t,
 		mapIntMetrics("int64.test", slice),
-		[]datadog.Metric{NewGauge("int64.test", int32(ts), 17, []string{})},
+		[]datadog.Metric{NewGauge("int64.test", uint64(ts), 17, []string{})},
 	)
 }
 
 func TestMapDoubleMetrics(t *testing.T) {
-	ts := time.Now().Unix()
+	ts := time.Now().UnixNano()
 	slice := pdata.NewDoubleDataPointSlice()
 
 	point := pdata.NewDoubleDataPoint()
@@ -85,12 +85,12 @@ func TestMapDoubleMetrics(t *testing.T) {
 
 	assert.ElementsMatch(t,
 		mapDoubleMetrics("float64.test", slice),
-		[]datadog.Metric{NewGauge("float64.test", int32(ts), math.Pi, []string{})},
+		[]datadog.Metric{NewGauge("float64.test", uint64(ts), math.Pi, []string{})},
 	)
 }
 
 func TestMapIntHistogramMetrics(t *testing.T) {
-	ts := time.Now().Unix()
+	ts := time.Now().UnixNano()
 	slice := pdata.NewIntHistogramDataPointSlice()
 
 	point := pdata.NewIntHistogramDataPoint()
@@ -105,13 +105,13 @@ func TestMapIntHistogramMetrics(t *testing.T) {
 	slice.Append(nilPoint)
 
 	noBuckets := []datadog.Metric{
-		NewGauge("intHist.test.count", int32(ts), 20, []string{}),
-		NewGauge("intHist.test.sum", int32(ts), 200, []string{}),
+		NewGauge("intHist.test.count", uint64(ts), 20, []string{}),
+		NewGauge("intHist.test.sum", uint64(ts), 200, []string{}),
 	}
 
 	buckets := []datadog.Metric{
-		NewGauge("intHist.test.count_per_bucket", int32(ts), 2, []string{"bucket_idx:0"}),
-		NewGauge("intHist.test.count_per_bucket", int32(ts), 18, []string{"bucket_idx:1"}),
+		NewGauge("intHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
+		NewGauge("intHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
 	}
 
 	assert.ElementsMatch(t,
@@ -126,7 +126,7 @@ func TestMapIntHistogramMetrics(t *testing.T) {
 }
 
 func TestMapDoubleHistogramMetrics(t *testing.T) {
-	ts := time.Now().Unix()
+	ts := time.Now().UnixNano()
 	slice := pdata.NewDoubleHistogramDataPointSlice()
 
 	point := pdata.NewDoubleHistogramDataPoint()
@@ -141,13 +141,13 @@ func TestMapDoubleHistogramMetrics(t *testing.T) {
 	slice.Append(nilPoint)
 
 	noBuckets := []datadog.Metric{
-		NewGauge("doubleHist.test.count", int32(ts), 20, []string{}),
-		NewGauge("doubleHist.test.sum", int32(ts), math.Pi, []string{}),
+		NewGauge("doubleHist.test.count", uint64(ts), 20, []string{}),
+		NewGauge("doubleHist.test.sum", uint64(ts), math.Pi, []string{}),
 	}
 
 	buckets := []datadog.Metric{
-		NewGauge("doubleHist.test.count_per_bucket", int32(ts), 2, []string{"bucket_idx:0"}),
-		NewGauge("doubleHist.test.count_per_bucket", int32(ts), 18, []string{"bucket_idx:1"}),
+		NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
+		NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
 	}
 
 	assert.ElementsMatch(t,

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -19,251 +19,144 @@ import (
 	"testing"
 	"time"
 
-	v1agent "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
-	metricstest "go.opentelemetry.io/collector/testutil/metricstestutil"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 func TestMetricValue(t *testing.T) {
 	var (
-		hostname string   = "unknown"
-		name     string   = "name"
-		value    float64  = math.Pi
-		ts       int32    = int32(time.Now().Unix())
-		tags     []string = []string{"tool:opentelemetry", "version:0.1.0"}
+		name  string   = "name"
+		value float64  = math.Pi
+		ts    int32    = int32(time.Now().Unix())
+		tags  []string = []string{"tool:opentelemetry", "version:0.1.0"}
 	)
 
-	metric := NewGauge(hostname, name, ts, value, tags)
-
-	assert.Equal(t, hostname, metric.GetHost())
+	metric := NewGauge(name, ts, value, tags)
 	assert.Equal(t, Gauge, metric.GetType())
 	assert.Equal(t, tags, metric.Tags)
 }
 
-var (
-	testHost   = "unknown"
-	testKeys   = [...]string{"key1", "key2", "key3"}
-	testValues = [...]string{"val1", "val2", ""}
-	testTags   = [...]string{"key1:val1", "key2:val2", "key3:n/a"}
-	logger     = zap.NewNop()
-)
+func TestGetTags(t *testing.T) {
+	labels := pdata.NewStringMap()
+	labels.InitFromMap(map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+ 		"key3": "",			   
+	})
 
-func NewMetricsData(metrics []*v1.Metric) []consumerdata.MetricsData {
-	return []consumerdata.MetricsData{{
-		Node: &v1agent.Node{
-			Identifier: &v1agent.ProcessIdentifier{
-				HostName: "unknown",
-			},
-		},
-		Resource: nil,
-		Metrics:  metrics,
-	}}
+	assert.ElementsMatch(t,
+		getTags(labels),
+		[...]string{"key1:val1", "key2:val2", "key3:n/a"},
+	)
 }
 
-func TestMapNumericMetric(t *testing.T) {
-	ts := time.Now()
+func TestMapIntMetrics(t *testing.T) {
+	ts := time.Now().Unix()
+	slice := pdata.NewIntDataPointSlice()
 
-	intValue := &v1.Point{
-		Timestamp: metricstest.Timestamp(ts),
-		Value:     &v1.Point_Int64Value{Int64Value: 17},
+	point := pdata.NewIntDataPoint()
+	point.InitEmpty()
+	point.SetValue(17)
+	point.SetTimestamp(pdata.TimestampUnixNano(ts))
+	slice.Append(point)
+
+	nilPoint := pdata.NewIntDataPoint()
+	slice.Append(nilPoint)
+
+	assert.ElementsMatch(t,
+		mapIntMetrics("int64.test", slice),
+		[]datadog.Metric{NewGauge("int64.test", int32(ts), 17, []string{})},
+	)
+}
+
+func TestMapDoubleMetrics(t *testing.T) {
+	ts := time.Now().Unix()
+	slice := pdata.NewDoubleDataPointSlice()
+
+	point := pdata.NewDoubleDataPoint()
+	point.InitEmpty()
+	point.SetValue(math.Pi)
+	point.SetTimestamp(pdata.TimestampUnixNano(ts))
+	slice.Append(point)
+
+	nilPoint := pdata.NewDoubleDataPoint()
+	slice.Append(nilPoint)
+
+	assert.ElementsMatch(t,
+		mapDoubleMetrics("float64.test", slice),
+		[]datadog.Metric{NewGauge("float64.test", int32(ts), math.Pi, []string{})},
+	)
+}
+
+func TestMapIntHistogramMetrics(t *testing.T) {
+	ts := time.Now().Unix()
+	slice := pdata.NewIntHistogramDataPointSlice()
+
+	point := pdata.NewIntHistogramDataPoint()
+	point.InitEmpty()
+	point.SetCount(20)
+	point.SetSum(200)
+	point.SetBucketCounts([]uint64{2, 18})
+	point.SetTimestamp(pdata.TimestampUnixNano(ts))
+	slice.Append(point)
+
+	nilPoint := pdata.NewIntHistogramDataPoint()
+	slice.Append(nilPoint)
+
+	noBuckets := []datadog.Metric{
+		NewGauge("intHist.test.count", int32(ts), 20, []string{}),
+		NewGauge("intHist.test.sum", int32(ts), 200, []string{}),
 	}
 
-	md := NewMetricsData([]*v1.Metric{
-		metricstest.Gauge("gauge.float64.test", testKeys[:],
-			metricstest.Timeseries(ts, testValues[:], metricstest.Double(ts, math.Pi))),
-		metricstest.Cumulative("cumulative.float64.test", testKeys[:],
-			metricstest.Timeseries(ts, testValues[:], metricstest.Double(ts, math.Pi))),
+	buckets := []datadog.Metric{
+		NewGauge("intHist.test.count_per_bucket", int32(ts), 2, []string{"bucket_idx:0"}),
+		NewGauge("intHist.test.count_per_bucket", int32(ts), 18, []string{"bucket_idx:1"}),
+	}
 
-		metricstest.GaugeInt("gauge.int64.test", testKeys[:],
-			metricstest.Timeseries(ts, testValues[:], intValue)),
-		metricstest.CumulativeInt("cumulative.int64.test", testKeys[:],
-			metricstest.Timeseries(ts, testValues[:], intValue)),
-	})
-
-	series, droppedTimeSeries := MapMetrics(logger, MetricsConfig{}, md)
-
-	assert.Equal(t, 0, droppedTimeSeries)
 	assert.ElementsMatch(t,
-		[]datadog.Metric{
-			NewGauge(
-				testHost,
-				"gauge.float64.test",
-				int32(ts.Unix()),
-				math.Pi,
-				testTags[:],
-			),
-			NewGauge(
-				testHost,
-				"cumulative.float64.test",
-				int32(ts.Unix()),
-				math.Pi,
-				testTags[:],
-			),
-			NewGauge(
-				testHost,
-				"gauge.int64.test",
-				int32(ts.Unix()),
-				17,
-				testTags[:],
-			),
-			NewGauge(
-				testHost,
-				"cumulative.int64.test",
-				int32(ts.Unix()),
-				17,
-				testTags[:],
-			),
-		},
-		series.metrics,
+		mapIntHistogramMetrics("intHist.test", slice, false), // No buckets
+		noBuckets,
 	)
 
-}
-
-func TestMapDistributionMetric(t *testing.T) {
-	ts := time.Now()
-	md := NewMetricsData([]*v1.Metric{
-		metricstest.GaugeDist("dist.test", testKeys[:],
-			metricstest.Timeseries(ts, testValues[:], metricstest.DistPt(ts, []float64{0.1, 0.2}, []int64{100, 200}))),
-	})
-
-	series, _ := MapMetrics(
-		logger,
-		MetricsConfig{Buckets: true},
-		md,
-	)
-
-	assert.ElementsMatch(t, []datadog.Metric{
-		NewGauge(
-			testHost,
-			"dist.test.count",
-			int32(ts.Unix()),
-			300,
-			testTags[:],
-		),
-		// The sum value is approximated by the metricstest
-		// package using lower bounds and counts:
-		// sum = ∑ bound(i-1) * count(i)
-		//     = 0*100 + 0.1*200
-		//     = 20
-		NewGauge(
-			testHost,
-			"dist.test.sum",
-			int32(ts.Unix()),
-			20,
-			testTags[:],
-		),
-		// The sum of squared deviations is set to 0 by the
-		// metricstest package
-		NewGauge(
-			testHost,
-			"dist.test.squared_dev_sum",
-			int32(ts.Unix()),
-			0,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"dist.test.count_per_bucket",
-			int32(ts.Unix()),
-			100,
-			append(testTags[:], "bucket_idx:0"),
-		),
-		NewGauge(
-			testHost,
-			"dist.test.count_per_bucket",
-			int32(ts.Unix()),
-			200,
-			append(testTags[:], "bucket_idx:1"),
-		),
-	},
-		series.metrics,
+	assert.ElementsMatch(t,
+		mapIntHistogramMetrics("intHist.test", slice, true), // buckets
+		append(noBuckets, buckets...),
 	)
 }
 
-func TestMapSummaryMetric(t *testing.T) {
-	ts := time.Now()
+func TestMapDoubleHistogramMetrics(t *testing.T) {
+	ts := time.Now().Unix()
+	slice := pdata.NewDoubleHistogramDataPointSlice()
 
-	summaryPoint := metricstest.Timeseries(
-		ts,
-		testValues[:],
-		metricstest.SummPt(ts, 5, 23, []float64{0, 50.1, 95, 100}, []float64{1, 22, 100, 300}),
+	point := pdata.NewDoubleHistogramDataPoint()
+	point.InitEmpty()
+	point.SetCount(20)
+	point.SetSum(math.Pi)
+	point.SetBucketCounts([]uint64{2, 18})
+	point.SetTimestamp(pdata.TimestampUnixNano(ts))
+	slice.Append(point)
+
+	nilPoint := pdata.NewDoubleHistogramDataPoint()
+	slice.Append(nilPoint)
+
+	noBuckets := []datadog.Metric{
+		NewGauge("doubleHist.test.count", int32(ts), 20, []string{}),
+		NewGauge("doubleHist.test.sum", int32(ts), math.Pi, []string{}),
+	}
+
+	buckets := []datadog.Metric{
+		NewGauge("doubleHist.test.count_per_bucket", int32(ts), 2, []string{"bucket_idx:0"}),
+		NewGauge("doubleHist.test.count_per_bucket", int32(ts), 18, []string{"bucket_idx:1"}),
+	}
+
+	assert.ElementsMatch(t,
+		mapDoubleHistogramMetrics("doubleHist.test", slice, false), // No buckets
+		noBuckets,
 	)
 
-	md := NewMetricsData([]*v1.Metric{
-		metricstest.Summary("summary.test", testKeys[:], summaryPoint),
-	})
-
-	series, _ := MapMetrics(
-		logger,
-		// Enable percentiles for test
-		MetricsConfig{Percentiles: true},
-		md,
+	assert.ElementsMatch(t,
+		mapDoubleHistogramMetrics("doubleHist.test", slice, true), // buckets
+		append(noBuckets, buckets...),
 	)
-
-	assert.ElementsMatch(t, []datadog.Metric{
-		NewGauge(
-			testHost,
-			"summary.test.count",
-			int32(ts.Unix()),
-			5,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"summary.test.sum",
-			int32(ts.Unix()),
-			23,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"summary.test.min",
-			int32(ts.Unix()),
-			1,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"summary.test.p50",
-			int32(ts.Unix()),
-			22,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"summary.test.p95",
-			int32(ts.Unix()),
-			100,
-			testTags[:],
-		),
-		NewGauge(
-			testHost,
-			"summary.test.max",
-			int32(ts.Unix()),
-			300,
-			testTags[:],
-		),
-	},
-		series.metrics,
-	)
-}
-
-func TestMapInvalid(t *testing.T) {
-	ts := time.Now()
-	md := NewMetricsData([]*v1.Metric{{
-		MetricDescriptor: &v1.MetricDescriptor{
-			Type: v1.MetricDescriptor_UNSPECIFIED,
-		},
-		Timeseries: []*v1.TimeSeries{metricstest.Timeseries(
-			ts, []string{}, metricstest.Double(ts, 0.0))},
-	}})
-
-	metrics, droppedTimeSeries := MapMetrics(logger, MetricsConfig{}, md)
-
-	assert.Equal(t, droppedTimeSeries, 1)
-	assert.Equal(t, metrics, Series{})
 }

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -20,7 +20,6 @@ exporters:
 
     metrics:
       namespace: opentelemetry
-      report_percentiles: false
 
   datadog/invalid:
     metrics:


### PR DESCRIPTION
### What does this PR do?

The OpenTelemetry project won't allow new components to use the OpenCensus intermediate format since they are deprecating this. This PR moves our exporter to use the new format which has been recently moved out of the internal packages.

### Additional notes

- Some parts are still internal so I can't really write unit tests for these.