### PR TITLE
Remove client validation

### DIFF
--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -15,9 +15,6 @@ package datadogexporter
 
 import (
 	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
 	"path"
 	"testing"
 
@@ -63,33 +60,8 @@ func TestCreateAPIMetricsExporter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Test with invalid API key
-
-	// Mock http server
-	tsInvalid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("{\"valid\": false}"))
-	}))
-	defer tsInvalid.Close()
-	cfg.Exporters["datadog/api"].(*Config).Metrics.Endpoint = tsInvalid.URL
 	ctx := context.Background()
 	exp, err := factory.CreateMetricsExporter(
-		ctx,
-		component.ExporterCreateParams{Logger: logger},
-		cfg.Exporters["datadog/api"],
-	)
-
-	assert.Equal(t, errors.New("provided Datadog API key is invalid: ***************************aaaaa"), err)
-	assert.Nil(t, exp)
-
-	// Override endpoint to return that the API key is valid
-	tsValid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("{\"valid\": true}"))
-	}))
-	defer tsValid.Close()
-	cfg.Exporters["datadog/api"].(*Config).Metrics.Endpoint = tsValid.URL
-
-	ctx = context.Background()
-	exp, err = factory.CreateMetricsExporter(
 		ctx,
 		component.ExporterCreateParams{Logger: logger},
 		cfg.Exporters["datadog/api"],

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -16,7 +16,6 @@ package datadogexporter
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/internaldata"
@@ -35,19 +34,10 @@ func newMetricsExporter(logger *zap.Logger, cfg *Config) (*metricsExporter, erro
 	client := datadog.NewClient(cfg.API.Key, "")
 	client.SetBaseUrl(cfg.Metrics.TCPAddr.Endpoint)
 
-	if ok, err := client.Validate(); err != nil {
-		logger.Warn("Error when validating API key", zap.Error(err))
-	} else if ok {
-		logger.Info("Provided Datadog API key is valid")
-	} else {
-		return nil, fmt.Errorf("provided Datadog API key is invalid: %s", cfg.API.GetCensoredKey())
-	}
-
 	// Calculate tags at startup
 	tags := cfg.TagsConfig.GetTags(false)
 
 	return &metricsExporter{logger, cfg, client, tags}, nil
-
 }
 
 func (exp *metricsExporter) processMetrics(series *Series) {


### PR DESCRIPTION
The zorkian API does not validate the API key unless you also have
an application key, even though the endpoint works without it.

I am removing this validation until this gets fixed on the zorkian library.