### PR TITLE
Push host metadata on startup

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -98,17 +98,13 @@ type TagsConfig struct {
 }
 
 // GetTags gets the default tags extracted from the configuration
-func (t *TagsConfig) GetTags(addHost bool) []string {
+func (t *TagsConfig) GetTags() []string {
 	tags := make([]string, 0, 4)
 
 	vars := map[string]string{
 		"env":     t.Env,
 		"service": t.Service,
 		"version": t.Version,
-	}
-
-	if addHost {
-		vars["host"] = t.Hostname
 	}
 
 	for name, val := range vars {

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -99,18 +99,10 @@ type TagsConfig struct {
 
 // GetTags gets the default tags extracted from the configuration
 func (t *TagsConfig) GetTags() []string {
-	tags := make([]string, 0, 4)
+	tags := make([]string, 0, len(t.Tags)+1)
 
-	vars := map[string]string{
-		"env":     t.Env,
-		"service": t.Service,
-		"version": t.Version,
-	}
-
-	for name, val := range vars {
-		if val != "" {
-			tags = append(tags, fmt.Sprintf("%s:%s", name, val))
-		}
+	if t.Env != "none" {
+		tags = append(tags, fmt.Sprintf("env:%s", t.Env))
 	}
 
 	tags = append(tags, t.Tags...)

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -84,23 +84,21 @@ func TestLoadConfig(t *testing.T) {
 
 func TestTags(t *testing.T) {
 	tc := TagsConfig{
-		Hostname: "customhost",
-		Env:      "customenv",
-		Service:  "customservice",
-		Version:  "customversion",
-		Tags:     []string{"key1:val1", "key2:val2"},
+		Env:     "customenv",
+		Service: "customservice",
+		Version: "customversion",
+		Tags:    []string{"key1:val1", "key2:val2"},
 	}
 
 	assert.ElementsMatch(t,
 		[]string{
-			"host:customhost",
 			"env:customenv",
 			"service:customservice",
 			"version:customversion",
 			"key1:val1",
 			"key2:val2",
 		},
-		tc.GetTags(true), // get host
+		tc.GetTags(), // get host
 	)
 }
 

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -84,7 +84,11 @@ func TestLoadConfig(t *testing.T) {
 
 func TestTags(t *testing.T) {
 	tc := TagsConfig{
-		Env:     "customenv",
+		// environment should be picked up if it is not 'none'
+		Env: "customenv",
+
+		// these should be ignored;
+		// they are used only on trace translation
 		Service: "customservice",
 		Version: "customversion",
 		Tags:    []string{"key1:val1", "key2:val2"},
@@ -93,13 +97,14 @@ func TestTags(t *testing.T) {
 	assert.ElementsMatch(t,
 		[]string{
 			"env:customenv",
-			"service:customservice",
-			"version:customversion",
 			"key1:val1",
 			"key2:val2",
 		},
-		tc.GetTags(), // get host
+		tc.GetTags(),
 	)
+
+	tc.Env = "none"
+	assert.ElementsMatch(t, tc.GetTags(), tc.Tags)
 }
 
 // TestOverrideMetricsURL tests that the metrics URL is overridden

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 const (
@@ -28,6 +29,9 @@ const (
 
 	// DefaultSite is the default site of the Datadog intake to send data to
 	DefaultSite = "datadoghq.com"
+
+	// maxRetries is the maximum number of retries for pushing host metadata
+	maxRetries = 5
 )
 
 // NewFactory creates a Datadog exporter factory
@@ -84,6 +88,25 @@ func createMetricsExporter(
 	exp, err := newMetricsExporter(params.Logger, cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	// Send host metadata
+	var sent bool
+	metadata := getHostMetadata(cfg)
+	for i := 0; i < maxRetries; i++ {
+		err := exp.pushHostMetadata(metadata)
+		if err != nil {
+			params.Logger.Warn("Sending host metadata failed", zap.Error(err))
+		} else {
+			sent = true
+			params.Logger.Info("Sent host metadata", zap.Int("numRetries", i))
+			break
+		}
+	}
+
+	if !sent {
+		// log and continue without metadata
+		params.Logger.Error("Could not send host metadata", zap.Int("numRetries", maxRetries))
 	}
 
 	return exporterhelper.NewMetricsExporter(

--- a/exporter/datadogexporter/host.go
+++ b/exporter/datadogexporter/host.go
@@ -20,12 +20,12 @@ import (
 )
 
 const (
-	opentelemetryFlavor  string = "opentelemetry-collector"
-	opentelemetryVersion string = "alpha"
+	opentelemetryFlavor  = "opentelemetry-collector"
+	opentelemetryVersion = "alpha"
 )
 
 var (
-	userAgent string = fmt.Sprintf("%s/%s", opentelemetryFlavor, opentelemetryVersion)
+	userAgent = fmt.Sprintf("%s/%s", opentelemetryFlavor, opentelemetryVersion)
 )
 
 // GetHost gets the hostname according to configuration.

--- a/exporter/datadogexporter/host.go
+++ b/exporter/datadogexporter/host.go
@@ -68,7 +68,7 @@ type hostTags struct {
 // meta includes metadata about the host aliases
 type meta struct {
 	// InstanceID is the EC2 instance id the Collector is running on, if available
-	InstanceID string `json:"instance-id,omitemtpy"`
+	InstanceID string `json:"instance-id,omitempty"`
 
 	// EC2Hostname is the hostname from the EC2 metadata API
 	EC2Hostname string `json:"ec2-hostname,omitempty"`

--- a/exporter/datadogexporter/host.go
+++ b/exporter/datadogexporter/host.go
@@ -14,11 +14,18 @@
 
 package datadogexporter
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 const (
 	opentelemetryFlavor  string = "opentelemetry-collector"
 	opentelemetryVersion string = "alpha"
+)
+
+var (
+	userAgent string = fmt.Sprintf("%s/%s", opentelemetryFlavor, opentelemetryVersion)
 )
 
 // GetHost gets the hostname according to configuration.

--- a/exporter/datadogexporter/host.go
+++ b/exporter/datadogexporter/host.go
@@ -16,6 +16,11 @@ package datadogexporter
 
 import "os"
 
+const (
+	opentelemetryFlavor  string = "opentelemetry-collector"
+	opentelemetryVersion string = "alpha"
+)
+
 // GetHost gets the hostname according to configuration.
 // It gets the configuration hostname and if
 // not available it relies on the OS hostname
@@ -29,4 +34,64 @@ func GetHost(cfg *Config) *string {
 		host = "unknown"
 	}
 	return &host
+}
+
+// hostMetadata includes metadata about the host tags,
+// host aliases and identifies the host as an OpenTelemetry host
+type hostMetadata struct {
+	// Meta includes metadata about the host.
+	Meta *meta `json:"meta"`
+
+	// InternalHostname is the canonical hostname
+	InternalHostname string `json:"internalHostname"`
+
+	// Version is the OpenTelemetry Collector version.
+	// This is used for correctly identifying the Collector in the backend,
+	// and for telemetry purposes.
+	Version string `json:"otel_version"`
+
+	// Flavor is always set to "opentelemetry-collector".
+	// It is used for telemetry purposes in the backend.
+	Flavor string `json:"agent-flavor"`
+
+	// Tags includes the host tags
+	Tags *hostTags `json:"host-tags"`
+}
+
+// hostTags are the host tags.
+// Currently only system (configuration) tags are considered.
+type hostTags struct {
+	// System are host tags set in the configuration
+	System []string `json:"system,omitempty"`
+}
+
+// meta includes metadata about the host aliases
+type meta struct {
+	// InstanceID is the EC2 instance id the Collector is running on, if available
+	InstanceID string `json:"instance-id,omitemtpy"`
+
+	// EC2Hostname is the hostname from the EC2 metadata API
+	EC2Hostname string `json:"ec2-hostname,omitempty"`
+
+	// Hostname is the canonical hostname
+	Hostname string `json:"hostname"`
+
+	// SocketHostname is the OS hostname
+	SocketHostname string `json:"socket-hostname"`
+
+	// HostAliases are other available host names
+	HostAliases []string `json:"host-aliases,omitempty"`
+}
+
+func getHostMetadata(cfg *Config) hostMetadata {
+	host := *GetHost(cfg)
+	return hostMetadata{
+		InternalHostname: host,
+		Flavor:           opentelemetryFlavor,
+		Version:          opentelemetryVersion,
+		Tags:             &hostTags{cfg.TagsConfig.GetTags()},
+		Meta: &meta{
+			Hostname: host,
+		},
+	}
 }

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -57,7 +57,7 @@ func (exp *metricsExporter) pushHostMetadata(metadata hostMetadata) error {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode/100 >= 4 {
+	if resp.StatusCode >= 400 {
 		return fmt.Errorf(
 			"'%d - %s' error when sending metadata payload to %s",
 			resp.StatusCode,

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -50,11 +50,12 @@ func (exp *metricsExporter) pushHostMetadata(metadata hostMetadata) error {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
 
 	if err != nil {
 		return err
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode/100 >= 4 {
 		return fmt.Errorf(

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -35,6 +35,7 @@ type metricsExporter struct {
 
 func newMetricsExporter(logger *zap.Logger, cfg *Config) (*metricsExporter, error) {
 	client := datadog.NewClient(cfg.API.Key, "")
+	client.ExtraHeader["User-Agent"] = userAgent
 	client.SetBaseUrl(cfg.Metrics.TCPAddr.Endpoint)
 
 	return &metricsExporter{logger, cfg, client}, nil
@@ -47,7 +48,7 @@ func (exp *metricsExporter) pushHostMetadata(metadata hostMetadata) error {
 	req, _ := http.NewRequest(http.MethodPost, path, bytes.NewBuffer(buf))
 	req.Header.Set("DD-API-KEY", exp.cfg.API.Key)
 	req.Header.Set("Content-Type", "application/json")
-
+	req.Header.Set("User-Agent", userAgent)
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -58,14 +58,14 @@ func TestProcessMetrics(t *testing.T) {
 			0,
 			[]string{"key2:val2"},
 		),
-	}	 
+	}
 
 	exp.processMetrics(metrics)
 
 	assert.Equal(t, "test_host", *metrics[0].Host)
 	assert.Equal(t, "test.metric_name", *metrics[0].Metric)
 	assert.ElementsMatch(t,
-		[]string{"key:val", "env:test_env", "key2:val2"},
+		[]string{"key2:val2"},
 		metrics[0].Tags,
 	)
 


### PR DESCRIPTION
### What does this PR do?

Push host metadata on startup. Currently it only sends the host tags, future PRs will add AWS instance ids and other host aliases that can be available.

I tested this against the backend and it shows the correct host tags and host aliases.