### PR TITLE
Correctly set default site

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -155,6 +155,11 @@ func (c *Config) Sanitize() error {
 
 	c.API.Key = strings.TrimSpace(c.API.Key)
 
+	// Set the Site option to the default
+	if c.API.Site == "" {
+		c.API.Site = "datadoghq.com"
+	}
+
 	// Set the endpoint based on the Site
 	if c.Metrics.TCPAddr.Endpoint == "" {
 		c.Metrics.TCPAddr.Endpoint = fmt.Sprintf("https://api.%s", c.API.Site)

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -141,3 +141,17 @@ func TestCensorAPIKey(t *testing.T) {
 		cfg.GetCensoredKey(),
 	)
 }
+
+// TestDefaultSiteEndpoint tests that the site and metrics URL are
+// correctly set to defaults when unspecified in the config.
+func TestDefaultSiteEndpoint(t *testing.T) {
+
+	cfg := Config{
+		API: APIConfig{Key: "notnull"},
+	}
+
+	err := cfg.Sanitize()
+	require.NoError(t, err)
+	assert.Equal(t, cfg.API.Site, "datadoghq.com")
+	assert.Equal(t, cfg.Metrics.Endpoint, "https://api.datadoghq.com")
+}


### PR DESCRIPTION
### What does this PR do?

In the `Sanitize` function, correctly set `API.Site` to its default value when unset.
Adds a test to verify default behavior.

### Motivation

When `API.Site` (an optional param) was not specified, the `Sanitize` operation did not replace it with the default `datadoghq.com`, leading to a misconfigured metrics endpoint (`https://api.`)