### PR TITLE
Send host tags as 'otel' instead of 'system'

### DIFF
--- a/exporter/datadogexporter/host.go
+++ b/exporter/datadogexporter/host.go
@@ -68,8 +68,8 @@ type hostMetadata struct {
 // hostTags are the host tags.
 // Currently only system (configuration) tags are considered.
 type hostTags struct {
-	// System are host tags set in the configuration
-	System []string `json:"system,omitempty"`
+	// OTel are host tags set in the configuration
+	OTel []string `json:"otel,omitempty"`
 }
 
 // meta includes metadata about the host aliases


### PR DESCRIPTION
So we can distinguish tags sent by the exporter from tags sent by a Datadog Agent.