### PR TITLE
Disable logs

### DIFF
--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -5,3 +5,6 @@ clusterRole:
   name: "opentelemetry-collector-gateway"
   clusterRoleBinding:
     name: opentelemetry-collector-gateway
+presets:
+  logsCollection:
+    enabled: false


### PR DESCRIPTION
Collector is in crashloop backoff:
```
➜  ~ kubectl get pod -n otel-gateway                                             
NAME                                                        READY   STATUS             RESTARTS        AGE
opentelemetry-collector-xxxxxxxxxxxxx                     1/1     Running            54 (12m ago)    17h
```

**Update:**
No Restarts since disabling logs: 
```
➜  ~ kubectl get pod -n otel-gateway
NAME                                                        READY   STATUS             RESTARTS        AGE
opentelemetry-collector-xxxxxxxxxxxxx                    1/1     Running            0               4h48m
```