### PR TITLE
Add Daemonset => Gateway Setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ build-ci-image:
     - TAG=ci-image-2
     - docker build --file ci/Dockerfile.gitlab --tag $BUILD_DD_REGISTRY:$TAG .
     - docker push $BUILD_DD_REGISTRY:$TAG
-staging-deploy-gateway-eks:
+.staging-deploy: &staging-deploy
   stage: staging-deploy
   tags: ["runner:docker", "size:large"]
   image: $CI_IMAGE
@@ -79,28 +79,23 @@ staging-deploy-gateway-eks:
     - export AWS_SECRET_ACCESS_KEY=$TEMP_AWS_SECRET_ACCESS_KEY
     # # For debugging
     # - aws sts get-caller-identity
-    - bash ./ci/scripts/ci-deploy-gateway.sh
-
+    - bash $SCRIPT $NAMESPACE $VALUES
 staging-deploy-demo-eks:
-  stage: staging-deploy
-  tags: ["runner:docker", "size:large"]
-  image: $CI_IMAGE
-  dependencies:
-    - push-image-staging
-  rules:
-    - if: '$CI_COMMIT_REF_NAME =~ /-staging$/'
-  script:
-    # # For debugging
-    #- aws sts get-caller-identity
-    - >-
-      TEMP_AWS_ACCESS_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-collector-contrib.sand-eks-deploy-api-key --with-decryption --query Parameter.Value --out text)
-    - >-
-      TEMP_AWS_SECRET_ACCESS_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.opentelemetry-collector-contrib.sand-eks-deploy-access-key --with-decryption --query Parameter.Value --out text)
-    - export AWS_ACCESS_KEY_ID=$TEMP_AWS_ACCESS_KEY_ID
-    - export AWS_SECRET_ACCESS_KEY=$TEMP_AWS_SECRET_ACCESS_KEY
-    # # For debugging
-    # - aws sts get-caller-identity
-    - bash ./ci/scripts/ci-deploy-staging.sh
+  !!merge <<: *staging-deploy
+  variables:
+    SCRIPT: ./ci/scripts/ci-deploy-staging.sh
+    NAMESPACE: otel-staging
+    VALUES: ./ci/values-staging.yaml
+staging-deploy-gateway-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    SCRIPT: ./ci/scripts/ci-deploy-staging.sh
+    NAMESPACE: otel-gateway
+    VALUES: ./ci/values-gateway.yaml
+staging-deploy-ds-gateway-eks:
+  !!merge <<: *staging-deploy
+  variables:
+    SCRIPT: ./ci/scripts/ci-deploy-ds-gateway.sh
 prod-deploy-demo-eks:
   stage: prod-deploy
   tags: ["runner:docker", "size:large"]

--- a/ci/scripts/ci-deploy-ds-gateway.sh
+++ b/ci/scripts/ci-deploy-ds-gateway.sh
@@ -12,15 +12,24 @@ set -x
 install_collector() {
 	# Set the namespace and release name
 	release_name="opentelemetry-collector"
-	namespace="otel-gateway"
+	release_name_gateway="opentelemetry-collector-gateway"
+	namespace="otel-ds-gateway"
 
 	# if repo already exists, helm 3+ will skip
 	helm --debug repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 
 	# --install will run `helm install` if not already present.
+    # gateway with DD exporter
+	helm --debug upgrade "${release_name_gateway}" -n "${namespace}" open-telemetry/opentelemetry-collector --install \
+		-f ./ci/values.yaml \
+		-f ./ci/values-ds-gateway.yaml \
+		--set-string image.tag="otelcolcontrib-v$CI_COMMIT_SHORT_SHA" \
+		--set-string image.repository="601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-collector-contrib"
+
+    # daemonset with otlp exporter
 	helm --debug upgrade "${release_name}" -n "${namespace}" open-telemetry/opentelemetry-collector --install \
 		-f ./ci/values.yaml \
-		-f ./ci/values-gateway.yaml \
+		-f ./ci/values-otlp-col.yaml \
 		--set-string image.tag="otelcolcontrib-v$CI_COMMIT_SHORT_SHA" \
 		--set-string image.repository="601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-collector-contrib"
 

--- a/ci/scripts/ci-deploy-staging.sh
+++ b/ci/scripts/ci-deploy-staging.sh
@@ -8,11 +8,11 @@
 set -euo pipefail
 IFS=$'\n\t'
 set -x
+namespace=$NAMESPACE
+values=$VALUES
 
 install_collector() {
-	# Set the namespace and release name
 	release_name="opentelemetry-collector"
-	namespace="otel-staging"
 
 	# if repo already exists, helm 3+ will skip
 	helm --debug repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
@@ -20,7 +20,7 @@ install_collector() {
 	# --install will run `helm install` if not already present.
 	helm --debug upgrade "${release_name}" -n "${namespace}" open-telemetry/opentelemetry-collector --install \
 		-f ./ci/values.yaml \
-		-f ./ci/values-staging.yaml \
+		-f "${values}" \
 		--set-string image.tag="otelcolcontrib-v$CI_COMMIT_SHORT_SHA" \
 		--set-string image.repository="601427279990.dkr.ecr.us-east-1.amazonaws.com/otel-collector-contrib"
 

--- a/ci/values-ds-gateway.yaml
+++ b/ci/values-ds-gateway.yaml
@@ -1,0 +1,11 @@
+mode: deployment
+replicaCount: 3
+nodeSelector:
+  alpha.eksctl.io/nodegroup-name: ng-6
+clusterRole:
+  name: "opentelemetry-collector-ds-gateway"
+  clusterRoleBinding:
+    name: opentelemetry-collector-ds-gateway
+presets:
+  logsCollection:
+    enabled: false

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -9,13 +9,6 @@ clusterRole:
 presets:
   logsCollection:
     enabled: false
-resources:
-  limits:
-    cpu: 800m
-    memory: 4Gi
-  requests:
-    cpu: 512m
-    memory: 2Gi
 config:
   processors:
     batch:

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -19,6 +19,6 @@ resources:
 config:
   processors:
     batch:
-      send_batch_max_size: 100
+      send_batch_max_size: 50
       send_batch_size: 10
       timeout: 10s

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -12,6 +12,6 @@ presets:
 config:
   processors:
     batch:
-      send_batch_max_size: 100
+      send_batch_max_size: 1000
       send_batch_size: 10
       timeout: 10s

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -1,4 +1,5 @@
 mode: deployment
+replicaCount: 6
 nodeSelector:
   alpha.eksctl.io/nodegroup-name: ng-5
 clusterRole:

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -9,3 +9,10 @@ clusterRole:
 presets:
   logsCollection:
     enabled: false
+resources:
+  limits:
+    cpu: 800m
+    memory: 4Gi
+  requests:
+    cpu: 512m
+    memory: 2Gi

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -9,9 +9,3 @@ clusterRole:
 presets:
   logsCollection:
     enabled: false
-config:
-  processors:
-    batch:
-      send_batch_max_size: 1000
-      send_batch_size: 100
-      timeout: 10s

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -12,6 +12,6 @@ presets:
 config:
   processors:
     batch:
-      send_batch_max_size: 50
+      send_batch_max_size: 100
       send_batch_size: 10
       timeout: 10s

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -1,5 +1,5 @@
 mode: deployment
-replicaCount: 6
+replicaCount: 3
 nodeSelector:
   alpha.eksctl.io/nodegroup-name: ng-5
 clusterRole:

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -13,5 +13,5 @@ config:
   processors:
     batch:
       send_batch_max_size: 1000
-      send_batch_size: 10
+      send_batch_size: 100
       timeout: 10s

--- a/ci/values-gateway.yaml
+++ b/ci/values-gateway.yaml
@@ -16,3 +16,9 @@ resources:
   requests:
     cpu: 512m
     memory: 2Gi
+config:
+  processors:
+    batch:
+      send_batch_max_size: 100
+      send_batch_size: 10
+      timeout: 10s

--- a/ci/values-otlp-col.yaml
+++ b/ci/values-otlp-col.yaml
@@ -1,0 +1,25 @@
+nodeSelector:
+  alpha.eksctl.io/nodegroup-name: ng-6
+clusterRole:
+  name: "opentelemetry-collector-ds"
+  clusterRoleBinding:
+    name: opentelemetry-collector-ds
+config:
+  exporters:
+    otlp:
+      endpoint: opentelemetry-collector-gateway:4317
+      tls:
+        insecure: true
+  service:
+    pipelines:
+      metrics:
+        exporters: [otlp]
+      traces:
+        exporters: [otlp]
+      logs:
+        exporters: [otlp]
+resources:
+  limits:
+    # necessary to decrease memory from 2 to 1 Gi in order to
+    # have sufficient memory to schedule all pods on Nodes.
+    memory: 1Gi

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -6,6 +6,6 @@ presets:
 config:
   processors:
     batch:
-      send_batch_max_size: 100
+      send_batch_max_size: 1000
       send_batch_size: 10
       timeout: 10s

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -6,6 +6,6 @@ presets:
 config:
   processors:
     batch:
-      send_batch_max_size: 50
+      send_batch_max_size: 100
       send_batch_size: 10
       timeout: 10s

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -1,2 +1,8 @@
 nodeSelector:
   alpha.eksctl.io/nodegroup-name: ng-3
+config:
+  processors:
+    batch:
+      send_batch_max_size: 50
+      send_batch_size: 10
+      timeout: 10s

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -3,9 +3,3 @@ nodeSelector:
 presets:
   logsCollection:
     enabled: false
-config:
-  processors:
-    batch:
-      send_batch_max_size: 1000
-      send_batch_size: 10
-      timeout: 10s

--- a/ci/values-staging.yaml
+++ b/ci/values-staging.yaml
@@ -1,5 +1,8 @@
 nodeSelector:
   alpha.eksctl.io/nodegroup-name: ng-3
+presets:
+  logsCollection:
+    enabled: false
 config:
   processors:
     batch:

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -7,7 +7,7 @@ securityContext:
   runAsGroup: 0
 resources:
   limits:
-    cpu: 256m
+    cpu: 512m
     memory: 2Gi
 presets:
   logsCollection:


### PR DESCRIPTION
This PR deploys a daemonset collector with the OTLP exporter which points to a gateway collector with the DD exporter on `ng-6`. 

This PR configures 3 replicas for the gateway in both `env:otel-gateway` and `env:otel-ds-gateway`.