### PR TITLE
Add resource attributes to Datadog OtelCollector payload

### DIFF
--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/service"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
@@ -176,6 +177,46 @@ func TestNotifyConfig(t *testing.T) {
 		// Ensure shutdown works cleanly
 		assert.NoError(t, ext.Shutdown(t.Context()))
 	})
+}
+
+func TestCollectorResourceAttributesArePopulated(t *testing.T) {
+	// Prepare TelemetrySettings with Resource attributes
+	tel := componenttest.NewNopTelemetrySettings()
+	res := pcommon.NewResource()
+	res.Attributes().PutStr("b_key", "2")
+	res.Attributes().PutStr("a_key", "1")
+	tel.Resource = res
+
+	set := extension.Settings{
+		TelemetrySettings: tel,
+		BuildInfo:         component.BuildInfo{Version: "1.2.3"},
+	}
+	hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
+	uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
+	cfg := &Config{
+		API: datadogconfig.APIConfig{Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Site: "datadoghq.com"},
+		HTTPConfig: &httpserver.Config{
+			ServerConfig: confighttp.ServerConfig{Endpoint: "localhost:0"},
+			Path:         "/test-path",
+		},
+	}
+
+	ext, err := newExtension(t.Context(), cfg, set, hostProvider, uuidProvider)
+	require.NoError(t, err)
+	ext.serializer = &mockSerializer{}
+	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
+
+	// Minimal config to trigger NotifyConfig
+	conf := confmap.NewFromStringMap(map[string]any{})
+	err = ext.NotifyConfig(t.Context(), conf)
+	require.NoError(t, err)
+
+	// Expect sorted ["a_key:1", "b_key:2"]
+	require.NotNil(t, ext.otelCollectorMetadata)
+	assert.Equal(t, []string{"a_key:1", "b_key:2"}, ext.otelCollectorMetadata.CollectorResourceAttributes)
+
+	// Cleanup
+	assert.NoError(t, ext.Shutdown(t.Context()))
 }
 
 func TestComponentStatusChanged(t *testing.T) {

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -49,6 +49,25 @@ func TestOtelCollectorPayload_MarshalJSON(t *testing.T) {
 	assert.Equal(t, oc.Metadata.FullComponents, unmarshaled.Metadata.FullComponents)
 }
 
+func TestOtelCollectorResourceAttributesJSON(t *testing.T) {
+	oc := &OtelCollectorPayload{
+		Hostname:  "test_host",
+		Timestamp: time.Now().UnixNano(),
+		UUID:      "test-uuid",
+		Metadata: OtelCollector{
+			CollectorResourceAttributes: []string{"key1:value1", "key2:value2"},
+		},
+	}
+
+	b, err := json.Marshal(oc)
+	require.NoError(t, err)
+
+	var back OtelCollectorPayload
+	err = json.Unmarshal(b, &back)
+	require.NoError(t, err)
+	assert.Equal(t, oc.Metadata.CollectorResourceAttributes, back.Metadata.CollectorResourceAttributes)
+}
+
 func TestOtelCollectorPayload_UnmarshalAndMarshal(t *testing.T) {
 	// Read the sample JSON payload from file
 	filePath := "testdata/sample-otelcollectorpayload.json"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"838ac87e-54d3-4b70-bb05-4960366c6ee3","source":"chat","resourceId":"07d398ab-2ac3-427c-a323-9800d9d157fc","workflowId":"5e9633f8-0d14-4272-9610-604eef110112","codeChangeId":"5e9633f8-0d14-4272-9610-604eef110112","sourceType":"chat"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=838ac87e-54d3-4b70-bb05-4960366c6ee3) for [Dev Agent Session](https://app.datadoghq.com/code/07d398ab-2ac3-427c-a323-9800d9d157fc)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

#### Description

This change adds a new field `collector_resource_attributes` to the `OtelCollector` struct in the internal payload, which is populated with resource attributes from `TelemetrySettings.Resource`. The resource attributes are formatted as a list of strings in the format `["key1:value1", "key2:value2"...]` and sorted alphabetically by key for consistency.

The implementation follows the pattern used in `extension/opampextension/opamp_agent.go` for accessing and storing resource attributes.

#### Link to tracking issue
Fixes

#### Testing

Added comprehensive test coverage:
- `TestCollectorResourceAttributesArePopulated()` verifies that resource attributes are correctly collected from TelemetrySettings, sorted alphabetically, and stored in the extension
- `TestOtelCollectorResourceAttributesJSON()` validates that the resource attributes are properly serialized and deserialized in JSON payloads

#### Documentation

The field is self-documenting through the code comments explaining the format and source of the resource attributes.