### PR TITLE
[draft] k8sattributes: minimally clean stale container.id associations

### DIFF
--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -1609,11 +1609,15 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 
 func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 	newPod := c.podFromAPI(pod)
+	identifiers := c.getIdentifiersFromAssoc(newPod)
+	var staleContainerIDRequests []deleteRequest
 
 	c.m.Lock()
-	defer c.m.Unlock()
-
-	identifiers := c.getIdentifiersFromAssoc(newPod)
+	if newPod.PodUID != "" {
+		if oldPod, ok := c.Pods[podUIDIdentifier(newPod.PodUID)]; ok && oldPod.PodUID == newPod.PodUID {
+			staleContainerIDRequests = c.staleContainerIDDeleteRequestsLocked(oldPod, newPod)
+		}
+	}
 	for i := range identifiers {
 		id := identifiers[i]
 		// compare initial scheduled timestamp for existing pod and new pod with same identifier
@@ -1627,18 +1631,108 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 		}
 		c.Pods[id] = newPod
 	}
+	c.m.Unlock()
+
+	c.appendDeleteRequests(staleContainerIDRequests)
 }
 
 func (c *WatchClient) forgetPod(pod *api_v1.Pod) {
 	podToRemove := c.podFromAPI(pod)
 	identifiers := c.getIdentifiersFromAssoc(podToRemove)
+	podUID := string(pod.UID)
+	var deleteRequests []deleteRequest
+
+	c.m.RLock()
+	seenInDeleteEvent := make(map[PodIdentifier]struct{}, len(identifiers))
 	for i := range identifiers {
 		id := identifiers[i]
-		p, ok := c.GetPod(id)
-
-		if ok && p.PodUID == string(pod.UID) {
-			c.appendDeleteQueue(id, p.PodUID)
+		seenInDeleteEvent[id] = struct{}{}
+		if p, ok := c.Pods[id]; ok && p.PodUID == podUID {
+			deleteRequests = append(deleteRequests, deleteRequest{id: id, podUID: p.PodUID})
 		}
+	}
+	if podUID != "" {
+		if cachedPod, ok := c.Pods[podUIDIdentifier(podUID)]; ok && cachedPod.PodUID == podUID {
+			// The delete event may not include historical container IDs. Include the
+			// latest cached pod state so container IDs known to the cache are deleted.
+			for _, id := range c.getIdentifiersFromAssoc(cachedPod) {
+				if _, ok := seenInDeleteEvent[id]; ok {
+					continue
+				}
+				if p, ok := c.Pods[id]; ok && p.PodUID == podUID {
+					deleteRequests = append(deleteRequests, deleteRequest{id: id, podUID: p.PodUID})
+				}
+			}
+		}
+	}
+	c.m.RUnlock()
+
+	c.appendDeleteRequests(deleteRequests)
+}
+
+func (c *WatchClient) staleContainerIDDeleteRequestsLocked(oldPod, newPod *Pod) []deleteRequest {
+	staleContainerIDs := staleContainerIDs(oldPod, newPod)
+	if len(staleContainerIDs) == 0 {
+		return nil
+	}
+
+	identifiers := c.getIdentifiersFromAssoc(oldPod)
+	requests := make([]deleteRequest, 0, len(staleContainerIDs))
+	seen := make(map[PodIdentifier]struct{}, len(identifiers))
+	for i := range identifiers {
+		id := identifiers[i]
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		if !podIdentifierHasContainerID(id, staleContainerIDs) {
+			continue
+		}
+		if p, ok := c.Pods[id]; ok && p.PodUID == oldPod.PodUID {
+			requests = append(requests, deleteRequest{id: id, podUID: oldPod.PodUID})
+		}
+	}
+	return requests
+}
+
+func staleContainerIDs(oldPod, newPod *Pod) map[string]struct{} {
+	if oldPod == nil || newPod == nil || oldPod.PodUID == "" || oldPod.PodUID != newPod.PodUID {
+		return nil
+	}
+
+	staleContainerIDs := map[string]struct{}{}
+	for containerID := range oldPod.Containers.ByID {
+		if containerID == "" {
+			continue
+		}
+		if _, ok := newPod.Containers.ByID[containerID]; !ok {
+			staleContainerIDs[containerID] = struct{}{}
+		}
+	}
+	return staleContainerIDs
+}
+
+func podIdentifierHasContainerID(id PodIdentifier, containerIDs map[string]struct{}) bool {
+	for i := range id {
+		attr := id[i]
+		if attr.Source.From == ResourceSource && attr.Source.Name == string(conventions.ContainerIDKey) {
+			if _, ok := containerIDs[attr.Value]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func podUIDIdentifier(podUID string) PodIdentifier {
+	return PodIdentifier{
+		PodIdentifierAttributeFromResourceAttribute(string(conventions.K8SPodUIDKey), podUID),
+	}
+}
+
+func (c *WatchClient) appendDeleteRequests(requests []deleteRequest) {
+	for i := range requests {
+		c.appendDeleteQueue(requests[i].id, requests[i].podUID)
 	}
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -57,6 +57,34 @@ func newPodIdentifier(from, name, value string) PodIdentifier {
 	}
 }
 
+func podWithContainerID(uid, containerID string, restartCount int32) *api_v1.Pod {
+	startTime := meta_v1.NewTime(time.Unix(1, 0))
+	return &api_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pod-a",
+			UID:  types.UID(uid),
+		},
+		Status: api_v1.PodStatus{
+			StartTime: &startTime,
+			ContainerStatuses: []api_v1.ContainerStatus{{
+				Name:         "container",
+				ContainerID:  "containerd://" + containerID,
+				RestartCount: restartCount,
+			}},
+		},
+	}
+}
+
+func assertDeleteQueueContains(t *testing.T, deleteQueue []deleteRequest, id PodIdentifier, podUID string) {
+	for i := range deleteQueue {
+		deleteRequest := deleteQueue[i]
+		if deleteRequest.id == id && deleteRequest.podUID == podUID {
+			return
+		}
+	}
+	assert.Failf(t, "missing delete request", "delete queue does not contain id %v for pod UID %q", id, podUID)
+}
+
 func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 	assert.Empty(t, c.Pods)
 
@@ -418,6 +446,69 @@ func TestPodUpdate(t *testing.T) {
 		// first argument (old pod) is not used right now
 		c.handlePodUpdate(&api_v1.Pod{}, obj)
 	})
+}
+
+func TestPodUpdateQueuesStaleContainerIDAssociation(t *testing.T) {
+	c, _ := newTestClient(t)
+	c.Rules = ExtractionRules{ContainerID: true}
+	c.Associations = []Association{{
+		Sources: []AssociationSource{{
+			From: ResourceSource,
+			Name: "container.id",
+		}},
+	}}
+
+	oldID := newPodIdentifier(ResourceSource, "container.id", "old-container-id")
+	newID := newPodIdentifier(ResourceSource, "container.id", "new-container-id")
+	pod := podWithContainerID("pod-uid", "old-container-id", 0)
+
+	c.handlePodAdd(pod)
+	require.Contains(t, c.Pods, oldID)
+	require.Contains(t, c.Pods, newPodIdentifier(ResourceSource, "k8s.pod.uid", "pod-uid"))
+
+	updatedPod := podWithContainerID("pod-uid", "new-container-id", 1)
+	c.handlePodUpdate(pod, updatedPod)
+
+	require.Contains(t, c.Pods, oldID)
+	require.Contains(t, c.Pods, newID)
+	require.Len(t, c.deleteQueue, 1)
+	assert.Equal(t, oldID, c.deleteQueue[0].id)
+	assert.Equal(t, "pod-uid", c.deleteQueue[0].podUID)
+
+	c.deleteLoopProcessing(time.Hour)
+	assert.Contains(t, c.Pods, oldID)
+	assert.Contains(t, c.Pods, newID)
+
+	c.deleteLoopProcessing(0)
+	assert.NotContains(t, c.Pods, oldID)
+	assert.Contains(t, c.Pods, newID)
+}
+
+func TestPodDeleteQueuesCachedContainerIDAssociation(t *testing.T) {
+	c, _ := newTestClient(t)
+	c.Rules = ExtractionRules{ContainerID: true}
+	c.Associations = []Association{{
+		Sources: []AssociationSource{{
+			From: ResourceSource,
+			Name: "container.id",
+		}},
+	}}
+
+	cachedID := newPodIdentifier(ResourceSource, "container.id", "cached-container-id")
+	pod := podWithContainerID("pod-uid", "cached-container-id", 0)
+	c.handlePodAdd(pod)
+	require.Contains(t, c.Pods, cachedID)
+
+	deletedPod := &api_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: "pod-a",
+			UID:  types.UID("pod-uid"),
+		},
+	}
+	c.handlePodDelete(deletedPod)
+
+	assertDeleteQueueContains(t, c.deleteQueue, cachedID, "pod-uid")
+	assertDeleteQueueContains(t, c.deleteQueue, newPodIdentifier(ResourceSource, "k8s.pod.uid", "pod-uid"), "pod-uid")
 }
 
 func TestNamespaceUpdate(t *testing.T) {


### PR DESCRIPTION
Draft alternative for discussing a smaller version of upstream open-telemetry/opentelemetry-collector-contrib#48398.

This intentionally scopes the fix to the observed leak for `container.id` associations:

- compare the cached pod looked up by `k8s.pod.uid` with the incoming pod update
- when a container ID disappears, queue delayed deletion only for `PodIdentifier`s that contain that stale `container.id`
- keep using the existing delete queue / grace period
- on pod delete, include identifiers derived from the cached pod so cached container IDs are not missed if the delete event omits historical statuses

This does not try to solve generic mutable/flapping association sources; that broader case remains out of scope for the upstream PR and can stay tracked separately.

Tested with:

```bash
cd processor/k8sattributesprocessor
go test ./internal/kube -count=1
```
