### PR TITLE
Stop using deprecated config module from the Datadog Agent

### DIFF
--- a/exporter/datadogexporter/internal/logs/package_test.go
+++ b/exporter/datadogexporter/internal/logs/package_test.go
@@ -14,8 +14,5 @@ func TestMain(m *testing.M) {
 		// We have to ignore seelog because of upstream issue
 		// https://github.com/cihub/seelog/issues/182
 		goleak.IgnoreAnyFunction("github.com/cihub/seelog.(*asyncLoopLogger).processQueue"),
-
-		// known goroutine leak http://github.com/DataDog/datadog-agent/issues/40071
-		goleak.IgnoreAnyFunction("github.com/DataDog/datadog-agent/pkg/config/viperconfig.(*safeConfig).processNotifications"),
 	)
 }

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -11,10 +11,10 @@ import (
 	corelog "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigcreate "github.com/DataDog/datadog-agent/pkg/config/create"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	zlib "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zlib"
 	"go.opentelemetry.io/collector/component"
@@ -97,7 +97,7 @@ func NewSerializerComponent(cfg coreconfig.Component, logger corelog.Component, 
 // This function uses the options pattern to allow different modules to configure
 // the component with their specific needs.
 func NewConfigComponent(options ...ConfigOption) coreconfig.Component {
-	pkgconfig := viperconfig.NewConfig("DD", "DD", strings.NewReplacer(".", "_"))
+	pkgconfig := pkgconfigcreate.NewConfig(name, "")
 
 	// Apply all configuration options
 	for _, opt := range options {

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.72.2
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.73.0-rc.8
+	github.com/DataDog/datadog-agent/pkg/config/create v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/config/model v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.73.0-rc.8
-	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.73.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics v0.73.0-rc.8
@@ -71,12 +71,12 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.73.0-rc.8 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/create v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.73.0-rc.8 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.73.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/metrics v0.73.0-rc.8 // indirect


### PR DESCRIPTION
#### Description

This PR use the dedicated `create` package to handle the Datadog config. `viperconfig` will soon be removed from the Agent repo.

#### Testing

There is no change in behavior introduced here. Running the CI will be enough.